### PR TITLE
resolves #3318 address variable fields in rpm -Va

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -518,10 +518,18 @@
     - CJIS-5.5.2.2
     with_items:
     - '{{ files_found.files }}'
+# using this awkward syntax of deleting then adding max_log_file
+# because repeated runs created extra instances of the setting
+# interestingly this was not ocurring with max_log_file_action
+# where the variable is a text string
 -   lineinfile:
-        dest: /etc/audit/auditd.conf
-        line: max_log_file {{ var_auditd_max_log_file }}
+        path: /etc/audit/auditd.conf
+        state: absent
+        regexp: '^max_log_file *'
+-   lineinfile:
+        path: /etc/audit/auditd.conf
         state: present
+        line: 'max_log_file = {{ var_auditd_max_log_file }}'
     name: Configure auditd Max Log File Size
     tags:
     - auditd_data_retention_max_log_file
@@ -577,9 +585,10 @@
     - CJIS-5.4.1.1
     - DISA-STIG-RHEL-07-030340
 -   lineinfile:
-        dest: /etc/audit/auditd.conf
-        line: max_log_file_action {{ var_auditd_max_log_file_action }}
+        path: /etc/audit/auditd.conf
         state: present
+        regexp: '^max_log_file_action *'
+        line: 'max_log_file_action = {{ var_auditd_max_log_file_action }}'
     name: Configure auditd max_log_file_action Upon Reaching Maximum Log Size
     tags:
     - auditd_data_retention_max_log_file_action

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2552,7 +2552,7 @@
     failed_when: false
     name: Read list of files with incorrect permissions
     register: files_with_incorrect_permissions
-    shell: rpm -Va | grep '^.M' | cut -d ' ' -f5- | sed -r 's;^.*\s+(.+);\1;g'
+    shell: rpm -Va | awk '/^.M/ {print $NF}'
     tags:
     - rpm_verify_permissions
     - high_severity


### PR DESCRIPTION
rpm -Va produced output describing the complaince of each constituent
file of all rpm on a given server. Prior logic did not allow for
varialbe number of fields, current logic uses awk and $NF to handle
this more cleanly